### PR TITLE
Add quality-of-life improvements for bodies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,14 @@ authors = [
 ]
 
 [features]
+json = ["dep:serde_json"]
+matching = []
+regex = ["dep:regex"]
 
 [dependencies]
+regex = { version = "1", optional = true }
 serde = { version = "1.0.127", features = ["derive"] }
+serde_json = { version = "1", optional = true }
 void = "1.0.2"
 chrono = "0.4.19"
 url = { version = "2.2.2", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -89,6 +89,44 @@ To deserialize `.yaml` Cassette files use
 $ cargo add vcr-cassette
 ```
 
+## Features
+
+* `json` -- enables parsing and comparison of JSON request and response bodies.
+  Saves having to escape every double quote character in your JSON-format bodies when you're manually
+  writing them.  Looks like this:
+
+  ```json
+  {
+    "body": {
+      "json": {
+        "arbitrary": ["json", "is", "now", "supported"],
+        "success_factor": 100,
+      }
+    }
+  }
+  ```
+
+* `matching` -- provides a mechanism for specifying "matchers" for request bodies, rather than a request body
+  having to be byte-for-byte compatible with what's specified in the cassette.  There are currently two match types available, `substring` and `regex` (if the `regex` feature is also enabled).
+  They do more-or-less what they say on the tin.  Use them like this:
+
+  ```json
+  {
+    "body": {
+      "matches": [
+        { "substring": "something" },
+        { "substring": "funny" },
+        { "regex": "\\d+" }
+      ]
+    }
+  }
+  ```
+
+  The above stanza, appropriately placed in a *request* specification, will match any request whose body contains the strings `"something"`, and `"funny"`, and *also* contains a number (of any length).
+
+* `regex` -- Enables the `regex` match type.
+  This is a separate feature, because the `regex` crate can be a bit heavyweight for resource-constrained environments, and so it's optional, in case you don't need it.
+
 ## Safety
 This crate uses ``#![deny(unsafe_code)]`` to ensure everything is implemented in
 100% Safe Rust.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -25,7 +25,8 @@ fn smoke_yaml() {
     for name in names {
         let name = format!("tests/fixtures/{}", name);
         println!("testing: {}", name);
-        let example = fs::read_to_string(name).unwrap();
-        let _out: Cassette = serde_yaml::from_str(&example).unwrap();
+        let example = fs::read_to_string(&name).unwrap();
+        let _out: Cassette =
+            serde_yaml::from_str(&example).expect(&format!("failed to parse {name}"));
     }
 }


### PR DESCRIPTION
On the request side, you can now match the request body against one or more substrings and regular expressions, which makes life easier for those of us who need to deal with request bodies that have non-deterministic elements in them (like nonces).

On the response side. you can now write your JSON response bodies *as JSON*, which is significantly easier than having to escape eleventy-billion quotes, and match up braces by eye.

To avoid any bloat or unpleasant interactions with existing code, all the new features are gated behind, well, features.